### PR TITLE
Removed default 25 count limit to retrieve all FROM addresses

### DIFF
--- a/sparkpost.php
+++ b/sparkpost.php
@@ -466,6 +466,7 @@ function sparkpost_getFromAddresses() {
     'sequential' => 1,
     'return' => 'label',
     'option_group_id' => 'from_email_address',
+    'options' => array('limit' => 0),
   ));
 
   foreach($result['values'] as $k => $value) {


### PR DESCRIPTION
In some cases, there can be a long list of FROM addresses. The default count of option values that the API retrieves is 25, so specifying a 0 limit, tells the API to retrieve all values, thus recording bounces for all efficiently.